### PR TITLE
Prevent running tests in generated `_site` dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "jest": {
     "testEnvironment": "jest-environment-jsdom",
+    "testPathIgnorePatterns": ["/_site"],
     "transform": {
       "^.+\\.jsx?$": "babel-jest"
     },


### PR DESCRIPTION
Seems that `npm run test` currently runs duplicated tests from the `client/src/_site` dir. My guess is that `/_site` contains files generated by Jekyll which shouldn't have been committed into the repo.

![image](https://github.com/user-attachments/assets/1bd38785-be68-4e21-8034-a212e9cb9fa1)

But anyways, we'll leave the `/_site` dir in the repo just in case. This PR just tell Jest to ignore it during `npm run test`.