### PR TITLE
Ignore failing test in `/test-examples` dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "jest": {
     "testEnvironment": "jest-environment-jsdom",
-    "testPathIgnorePatterns": ["/_site"],
+    "testPathIgnorePatterns": ["/_site", "/tests-examples"],
     "transform": {
       "^.+\\.jsx?$": "babel-jest"
     },


### PR DESCRIPTION
This will avoid running the failing test at `/tests-examples/demo-todo-app.spec.js`.