### PR TITLE
Pass failing tests

### DIFF
--- a/client/src/pages/Auth/Login.test.js
+++ b/client/src/pages/Auth/Login.test.js
@@ -135,7 +135,8 @@ describe('Login Component', () => {
         expect(toast.error).toHaveBeenCalledWith('Something went wrong')
     })
 
-    it('navigates to Account Recovery page when Forgot Password button is clicked', async () => {
+    // Website is missing a `/forgot-password` page.
+    it.failing('navigates to Account Recovery page when Forgot Password button is clicked', async () => {
       const { getByText } = render(
         <MemoryRouter initialEntries={['/login']}>
           <Routes>

--- a/client/src/pages/ProductDetails.test.js
+++ b/client/src/pages/ProductDetails.test.js
@@ -190,7 +190,9 @@ describe('Product Details Component', () => {
         });
     });
 
-    it('should allow the user to add the product to their cart', async () => {
+    // The "ADD TO CART" button doesn't do anything. Doesn't add product to cart
+    // nor display the toast message "Item Added to cart".
+    it.failing('should allow the user to add the product to their cart', async () => {
         const { getByText, getByRole } = render(
             <MemoryRouter initialEntries={['/product/' + JEANS_PRODUCT_OBJECT.slug]}>
                 <ProductDetails />

--- a/client/src/pages/Search.test.js
+++ b/client/src/pages/Search.test.js
@@ -113,7 +113,7 @@ describe('Search Component', () => {
     });
 
     // THIS SHOULD FAIL, THE MORE DETAILS BUTTON CURRENTLY DOESNT WORK
-    it('should navigate to the product details page when a user clicks on the "More Details" button', async () => {
+    it.failing('should navigate to the product details page when a user clicks on the "More Details" button', async () => {
         useSearch.mockReturnValue([{
             results: SEARCH_VALID_PRODUCT_SINGLE_RESULT,
             keyword: SEARCH_VALID_PRODUCT_NAME
@@ -133,7 +133,7 @@ describe('Search Component', () => {
     });
 
     // THIS SHOULD ALSO FAIL, THE ADD TO CART BUTTON CURRENTLY ALSO DOESNT WORK
-    it('should add the product to the cart when a user clicks on the "ADD TO CART" button', async () => {
+    it.failing('should add the product to the cart when a user clicks on the "ADD TO CART" button', async () => {
         useSearch.mockReturnValue([{
             results: SEARCH_VALID_PRODUCT_SINGLE_RESULT,
             keyword: SEARCH_VALID_PRODUCT_NAME

--- a/client/src/pages/admin/CreateCategory.test.js
+++ b/client/src/pages/admin/CreateCategory.test.js
@@ -98,7 +98,7 @@ describe('CreateCategory Component', () => {
     })
 
     // Displays misspelled toast message "somthing went wrong in input form".
-    it.skip('displays error toast when category creation fails', async () => {
+    it.failing('displays error toast when category creation fails', async () => {
         axios.get.mockResolvedValueOnce({ data: { success: true, category: [] } })
         axios.post.mockRejectedValueOnce(new Error('Creation failed'))
 
@@ -141,7 +141,7 @@ describe('CreateCategory Component', () => {
     })
 
     // Displays misspelled toast message "Something wwent wrong in getting catgeory".
-    it.skip('handles error when fetching categories fails due to unreachable server', async () => {
+    it.failing('handles error when fetching categories fails due to unreachable server', async () => {
         axios.get.mockRejectedValueOnce({
             isAxiosError: true,
             code: 'ECONNABORTED',
@@ -162,7 +162,7 @@ describe('CreateCategory Component', () => {
     })
 
     // Displays misspelled toast message "Something wwent wrong in getting catgeory".
-    it.skip('handles error when fetching categories fails due to 500 Internal Server Error', async () => {
+    it.failing('handles error when fetching categories fails due to 500 Internal Server Error', async () => {
         axios.get.mockRejectedValueOnce({
             response: {
                 status: 500,
@@ -342,7 +342,7 @@ describe('CreateCategory Component', () => {
 
     // Displays a toast message "somthing went wrong in input form" which is
     // both misspelled, and also not the error message returned by the backend.
-    it.skip('shows error when trying to create category with empty name', async () => {
+    it.failing('shows error when trying to create category with empty name', async () => {
         const mockCategories = [
             { _id: '1', name: 'Category 1' },
             { _id: '2', name: 'Category 2' },
@@ -381,7 +381,7 @@ describe('CreateCategory Component', () => {
 
     // Displays the toast message "somthing went wrong in input form" which is
     // both misspelled, and also not the error message returned by the backend.
-    it.skip('shows error when creating category with existing name', async () => {
+    it.failing('shows error when creating category with existing name', async () => {
         const mockCategories = [
             { _id: '1', name: 'Category 1' },
             { _id: '2', name: 'Category 2' },
@@ -418,7 +418,7 @@ describe('CreateCategory Component', () => {
 
     // Displays the toast message "Somtihing went wrong" which is both
     // misspelled, and also not the error message returned by the backend.
-    it.skip('shows error when editing category to an existing name', async () => {
+    it.failing('shows error when editing category to an existing name', async () => {
         const mockCategories = [
             { _id: '1', name: 'Category 1' },
             { _id: '2', name: 'Category 2' },

--- a/client/src/pages/admin/CreateProduct.js
+++ b/client/src/pages/admin/CreateProduct.js
@@ -46,7 +46,7 @@ const CreateProduct = () => {
       productData.append("quantity", quantity);
       productData.append("photo", photo);
       productData.append("category", category);
-      const { data } = axios.post(
+      const { data } = await axios.post(
         "/api/v1/product/create-product",
         productData
       );

--- a/client/src/pages/admin/CreateProduct.test.js
+++ b/client/src/pages/admin/CreateProduct.test.js
@@ -138,7 +138,7 @@ describe('CreateProduct Component', () => {
 
     // UI crashes on erroneous inputs:
     // https://github.com/cs4218/cs4218-project-2024-team04/issues/13
-    // Even when it doesn't crash, it will display a toast message "something
+    // Edit: Fixed runtime error but UI displays a toast message "something
     // went wrong" which is not the error message returned by the backend.
     it.failing('displays error message when submitting empty form', async () => {
         const BACKEND_ERROR_MESSAGE = 'ERROR MESSAGE'

--- a/client/src/pages/admin/CreateProduct.test.js
+++ b/client/src/pages/admin/CreateProduct.test.js
@@ -140,7 +140,7 @@ describe('CreateProduct Component', () => {
     // https://github.com/cs4218/cs4218-project-2024-team04/issues/13
     // Even when it doesn't crash, it will display a toast message "something
     // went wrong" which is not the error message returned by the backend.
-    it.skip('displays error message when submitting empty form', async () => {
+    it.failing('displays error message when submitting empty form', async () => {
         const BACKEND_ERROR_MESSAGE = 'ERROR MESSAGE'
         axios.post.mockRejectedValueOnce({
             response: {
@@ -171,7 +171,7 @@ describe('CreateProduct Component', () => {
 
     // UI doesn't send the "shipping" product value in its POST request to the
     // server.
-    it.skip('creates a new product successfully with correct form data', async () => {
+    it.failing('creates a new product successfully with correct form data', async () => {
         let capturedFormData
         axios.post.mockImplementation((url, data) => {
             capturedFormData = data

--- a/client/src/pages/admin/Products.test.js
+++ b/client/src/pages/admin/Products.test.js
@@ -74,7 +74,7 @@ describe('Products Component', () => {
     })
 
     // Displays misspelled toast message "Someething Went Wrong".
-    it.skip('handles API error', async () => {
+    it.failing('handles API error', async () => {
         axios.get.mockRejectedValueOnce(new Error('API Error'))
 
         render(

--- a/client/src/pages/admin/UpdateProduct.js
+++ b/client/src/pages/admin/UpdateProduct.js
@@ -70,7 +70,7 @@ const UpdateProduct = () => {
       productData.append("quantity", quantity);
       photo && productData.append("photo", photo);
       productData.append("category", category);
-      const { data } = axios.put(
+      const { data } = await axios.put(
         `/api/v1/product/update-product/${id}`,
         productData
       );

--- a/client/src/pages/admin/UpdateProduct.test.js
+++ b/client/src/pages/admin/UpdateProduct.test.js
@@ -166,6 +166,8 @@ describe('UpdateProduct Component', () => {
     })
 
     // UI crashes with runtime error when user submits invalid product values (eg. empty price)
+    // Edit: Fixed runtime error but UI displays a toast message "something went
+    // wrong" which is not the error message returned by the backend.
     it.failing('displays error message when product update fails', async () => {
         const BACKEND_ERROR_MESSAGE = 'ERROR MESSAGE'
         axios.put.mockRejectedValueOnce({

--- a/client/src/pages/admin/UpdateProduct.test.js
+++ b/client/src/pages/admin/UpdateProduct.test.js
@@ -166,7 +166,7 @@ describe('UpdateProduct Component', () => {
     })
 
     // UI crashes with runtime error when user submits invalid product values (eg. empty price)
-    it.skip('displays error message when product update fails', async () => {
+    it.failing('displays error message when product update fails', async () => {
         const BACKEND_ERROR_MESSAGE = 'ERROR MESSAGE'
         axios.put.mockRejectedValueOnce({
             response: {
@@ -196,7 +196,7 @@ describe('UpdateProduct Component', () => {
     })
 
     // Displays misspelled toast message "Product DEleted Succfully".
-    it.skip('calls delete API when "DELETE PRODUCT" button is clicked and confirmed', async () => {
+    it.failing('calls delete API when "DELETE PRODUCT" button is clicked and confirmed', async () => {
         axios.delete.mockResolvedValueOnce({ data: { success: true } })
         window.prompt = jest.fn(() => 'yes')
 

--- a/client/src/pages/admin/UpdateProduct.test.js
+++ b/client/src/pages/admin/UpdateProduct.test.js
@@ -145,8 +145,15 @@ describe('UpdateProduct Component', () => {
         })
     })
 
-    it('calls update API when "UPDATE PRODUCT" button is clicked', async () => {
-        axios.put.mockResolvedValueOnce({ data: { success: true } })
+    // Displays a correctly spelled toast message "Product Updated Successfully"
+    // but its a `toast.error` rather than `toast.success`; and it isn't the
+    // message returned by the backend.
+    // https://github.com/cs4218/cs4218-project-2024-team04/issues/15
+    it.failing('calls update API when "UPDATE PRODUCT" button is clicked', async () => {
+        const UPDATE_SUCCESS_MESSAGE = 'SUCCESS MESSAGE'
+        axios.put.mockResolvedValueOnce({
+            data: { success: true, message: UPDATE_SUCCESS_MESSAGE },
+        })
 
         render(
             <MemoryRouter>
@@ -161,7 +168,7 @@ describe('UpdateProduct Component', () => {
         })
 
         expect(axios.put).toHaveBeenCalled()
-        expect(toast.success).toHaveBeenCalledWith('Product Updated Successfully')
+        expect(toast.success).toHaveBeenCalledWith(UPDATE_SUCCESS_MESSAGE)
         expect(mockNavigate).toHaveBeenCalledWith('/dashboard/admin/products')
     })
 

--- a/client/src/pages/admin/UpdateProduct.test.js
+++ b/client/src/pages/admin/UpdateProduct.test.js
@@ -204,9 +204,13 @@ describe('UpdateProduct Component', () => {
         })
     })
 
-    // Displays misspelled toast message "Product DEleted Succfully".
+    // Displays misspelled toast message "Product DEleted Succfully", and it
+    // isn't the message returned by the backend.
     it.failing('calls delete API when "DELETE PRODUCT" button is clicked and confirmed', async () => {
-        axios.delete.mockResolvedValueOnce({ data: { success: true } })
+        const UPDATE_SUCCESS_MESSAGE = 'SUCCESS MESSAGE'
+        axios.delete.mockResolvedValueOnce({
+            data: { success: true, message: UPDATE_SUCCESS_MESSAGE },
+        })
         window.prompt = jest.fn(() => 'yes')
 
         render(
@@ -222,7 +226,7 @@ describe('UpdateProduct Component', () => {
         })
 
         expect(axios.delete).toHaveBeenCalled()
-        expect(toast.success).toHaveBeenCalledWith('Product Deleted Successfully')
+        expect(toast.success).toHaveBeenCalledWith(UPDATE_SUCCESS_MESSAGE)
         expect(mockNavigate).toHaveBeenCalledWith('/dashboard/admin/products')
     })
 


### PR DESCRIPTION
This PR passes the current failing tests (failing from bugs in the UI) by suffixing the `it` function with `.failing`.

This will make the tests pass on failure, and fail on passing. Kind of saying "we expect this test to fail".

```js
it("TEST NAME", async () => {
// is changed to
it.failing("TEST NAME", async () => {
```

For each of the `it.failing` tests, I've added a comment above it (if it didn't exist yet) to explain why it's failing.

## Edit: Prof gave the OK

![image](https://github.com/user-attachments/assets/015de8b3-b56c-49e1-9c19-acbf8dc665dd)
