### PR TITLE
Replace `npm install` -> `npm ci` for GH workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,5 +26,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm install && cd client && npm install && cd ..
+    - run: npm ci && cd client && npm ci && cd ..
     - run: npm run test


### PR DESCRIPTION
Since #9 fix the failing `npm ci`, I was thinking we change the GH workflow back to using `npm ci`. Since `npm ci` installs the exact versions that we're using rather than `>= [VERSION]`.

## Edit:
seems like the GH workflow checks with the new `npm ci` are passing

@cadencjk 